### PR TITLE
fix: unhandledRejection compatibility fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@ class Graceful {
     });
 
     // handle uncaught promises
-    process.on('unhandledRejection', this.logger.error.bind(this.logger));
+    process.on('unhandledRejection', (err) => {
+      this.logger.error(err);
+    });
 
     // handle uncaught exceptions
     process.once('uncaughtException', (err) => {


### PR DESCRIPTION
`unhandledRejection` passes two parameters, the error and the promise that threw it. For logging purposes the Promise is without use, but using bind and taking both parameters causes incompatibility with some popular logging libraries ([eg.](https://www.npmjs.com/package/pino)) that expects a signature of either `error` or `message, error` and then logs no error when it gets `error, Promise`.