### PR TITLE
fix: Make constructor options optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,20 @@
-declare module '@ladjs/graceful' {
-  export interface GracefulOptions {
-    servers?: Array<{ close(): unknown }>;
-    mongooses?: Array<{ disconnect(): Promise<void> }>;
-    bulls?: Array<{ close(): unknown }>;
-    brees?: Array<{ stop(): Promise<void> }>;
-    redisClients?: Array<{ disconnect(): unknown }>;
-    customHandlers?: Array<() => unknown>;
-    timeoutMs?: number;
-    logger?: {
-      info(): unknown;
-      warn(): unknown;
-      error(): unknown;
-    };
-  }
-  export default class Graceful {
-    constructor(options: GracefulOptions);
-    listen(): void;
-    exit(code: number | string): Promise<void>;
-  }
+export interface GracefulOptions {
+  servers?: Array<{ close(): unknown }>;
+  mongooses?: Array<{ disconnect(): Promise<void> }>;
+  bulls?: Array<{ close(): unknown }>;
+  brees?: Array<{ stop(): Promise<void> }>;
+  redisClients?: Array<{ disconnect(): unknown }>;
+  customHandlers?: Array<() => unknown>;
+  timeoutMs?: number;
+  logger?: {
+    info(): unknown;
+    warn(): unknown;
+    error(): unknown;
+  };
+}
+
+export default class Graceful {
+  constructor(options?: GracefulOptions);
+  listen(): void;
+  exit(code: number | string): Promise<void>;
 }


### PR DESCRIPTION
I've removed the `declare module` since it is redundant.

closes #9 