### PR TITLE
fix(types): make Logger type permit arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 type Logger = {
-  info(): unknown;
-  warn(): unknown;
-  error(): unknown;
+  info(...args: unknown[]): unknown;
+  warn(...args: unknown[]): unknown;
+  error(...args: unknown[]): unknown;
 };
 
 type LilHttpTerminator = {


### PR DESCRIPTION
I am making this PR because the current types are incompatible with some loggers, that export types for logging functions that has arguments. An example of this is [Pino's LogFn](https://github.com/pinojs/pino/blob/5dd282cfe76334e5a32f9d2b5340bd937a6dacea/pino.d.ts#L313).

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

